### PR TITLE
Adding DELETE endpoint and its tests for HelpRequest controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -71,4 +71,16 @@ public class HelpRequestController extends ApiController {
 
         return savedHelpRequest;
     }
+
+    @Operation(summary= "Delete a help request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteHelpRequest(
+            @Parameter(name="id") @RequestParam Long id) {
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        helpRequestRepository.delete(helpRequest);
+        return genericMessage("HelpRequest with id %s deleted".formatted(id));
+    }
 }


### PR DESCRIPTION
In this PR, we add the DELETE endpoint and the tests for this endpoint to the HelpRequest Controller. 

Link to updated dev deployment: https://team02-bradenc24-dev.dokku-02.cs.ucsb.edu

Closes #36 